### PR TITLE
Fix native Things view parity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ The `st` JSON field maps to the `start` column in Things' SQLite DB. It represen
 | 0 | `TaskScheduleInbox` | null | Inbox |
 | 1 | `TaskScheduleAnytime` | before next UTC day | Today and Anytime |
 | 1 | `TaskScheduleAnytime` | null/future | Anytime |
-| 2 | `TaskScheduleSomeday` | future date or recurrence link (`rt`) | Upcoming |
+| 2 | `TaskScheduleSomeday` | future date or repeater rule (`rr`) | Upcoming |
 | 2 | `TaskScheduleSomeday` | standalone, non-recurring, not future | Someday |
 
 These are locally derived views. By default they exclude canceled, deleted, trashed, and hidden-by-parent tasks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,10 +86,12 @@ The `st` JSON field maps to the `start` column in Things' SQLite DB. It represen
 | `st` | Constant | + `sr`/`tir` | Things view |
 |------|----------|-------------|-------------|
 | 0 | `TaskScheduleInbox` | null | Inbox |
-| 1 | `TaskScheduleAnytime` | today's date | Today |
-| 1 | `TaskScheduleAnytime` | null | Anytime |
-| 2 | `TaskScheduleSomeday` | future date | Upcoming |
-| 2 | `TaskScheduleSomeday` | null | Someday |
+| 1 | `TaskScheduleAnytime` | before next UTC day | Today and Anytime |
+| 1 | `TaskScheduleAnytime` | null/future | Anytime |
+| 2 | `TaskScheduleSomeday` | future date or recurrence link (`rt`) | Upcoming |
+| 2 | `TaskScheduleSomeday` | standalone, non-recurring, not future | Someday |
+
+These are locally derived views. By default they exclude canceled, deleted, trashed, and hidden-by-parent tasks.
 
 See `docs/client-side-bugs.md` for the full investigation.
 
@@ -100,4 +102,6 @@ The example app and real usage require:
 - `THINGS_PASSWORD` — Things account password
 - `API_KEY` — Bearer token for `/api/*` endpoints (optional, no auth if unset)
 - `PORT` — Server port (default: `8080`)
+- `BIND_ADDR` — Interface to bind (use `127.0.0.1` for a Mac-local service)
+- `DB_PATH` — SQLite mirror path (default: `/data/things.db`)
 - `DEBUG` — Enable verbose HTTP request/response logging when `true`

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Once connected, Claude can do pretty much everything you'd do in the Things app:
 - **Shutdown is graceful.** `SIGINT` and `SIGTERM` trigger an HTTP shutdown with a timeout instead of dropping in-flight requests immediately.
 - **Read surfaces support pagination.** REST list endpoints and the corresponding MCP list tools accept optional `limit` and `offset` values.
 - **Old `tir`/`sr` cache corruption is repaired automatically.** Opening a pre-fix sync database triggers a one-time local cache reset and full resync from Things Cloud history.
+- **Native view parity is testable on macOS.** Run `go run ./cmd/parity -url http://127.0.0.1:8765` to compare Today, Inbox, Anytime, Someday, and Upcoming UUIDs with Things 3 through AppleScript. The command exits non-zero on any mismatch.
+- **Mac-local deployments can bind only to loopback.** Set `BIND_ADDR=127.0.0.1`; use `DB_PATH` to choose the persistent SQLite mirror location.
 - **Soft-deleted rows are purged from the local cache after sync.** This keeps the SQLite mirror from growing forever while preserving normal sync semantics.
 
 ## Getting started

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -96,6 +96,16 @@ Shows:
 - Today view with reschedule warnings
 - Accountability check for problematic tasks
 
+### parity
+
+Read-only macOS check that compares native Things 3 UUIDs with a running MCP server for Today, Inbox, Anytime, Someday, and Upcoming.
+
+```bash
+go run ./cmd/parity -url http://127.0.0.1:8765
+```
+
+Every view must report `missing=0 extra=0`. The command exits non-zero on a mismatch or unavailable source.
+
 ---
 
 ## Debug & Development Tools

--- a/cmd/parity/main.go
+++ b/cmd/parity/main.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type view struct {
+	name string
+	path string
+}
+
+var views = []view{
+	{name: "Today", path: "today"},
+	{name: "Inbox", path: "inbox"},
+	{name: "Anytime", path: "anytime"},
+	{name: "Someday", path: "someday"},
+	{name: "Upcoming", path: "upcoming"},
+}
+
+type task struct {
+	UUID string `json:"uuid"`
+}
+
+func main() {
+	defaultURL := os.Getenv("THINGS_MCP_URL")
+	if defaultURL == "" {
+		defaultURL = "http://127.0.0.1:8765"
+	}
+	baseURL := flag.String("url", defaultURL, "Things MCP base URL")
+	timeout := flag.Duration("timeout", 2*time.Minute, "overall comparison timeout")
+	flag.Parse()
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	mismatch, err := compareViews(ctx, os.Stdout, strings.TrimRight(*baseURL, "/"), nativeViewIDs, mcpViewIDs)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "parity check failed:", err)
+		os.Exit(2)
+	}
+	if mismatch {
+		os.Exit(1)
+	}
+}
+
+type idReader func(context.Context, string) ([]string, error)
+
+func compareViews(ctx context.Context, out io.Writer, baseURL string, nativeIDs, mcpIDs idReader) (bool, error) {
+	mismatch := false
+	for _, item := range views {
+		native, err := nativeIDs(ctx, item.name)
+		if err != nil {
+			return false, fmt.Errorf("read native %s: %w", item.name, err)
+		}
+		mcp, err := mcpIDs(ctx, baseURL+"/api/tasks/"+item.path)
+		if err != nil {
+			return false, fmt.Errorf("read MCP %s: %w", item.name, err)
+		}
+
+		missing, extra := diffIDs(native, mcp)
+		fmt.Fprintf(out, "%s native=%d mcp=%d missing=%d extra=%d\n", item.name, len(native), len(mcp), len(missing), len(extra))
+		if len(native) != len(mcp) {
+			mismatch = true
+		}
+		if len(missing) > 0 {
+			fmt.Fprintf(out, "  missing: %s\n", strings.Join(missing, ", "))
+			mismatch = true
+		}
+		if len(extra) > 0 {
+			fmt.Fprintf(out, "  extra: %s\n", strings.Join(extra, ", "))
+			mismatch = true
+		}
+	}
+	return mismatch, nil
+}
+
+func nativeViewIDs(ctx context.Context, viewName string) ([]string, error) {
+	script := fmt.Sprintf(`tell application "Things3" to id of every to do of list %q`, viewName)
+	output, err := exec.CommandContext(ctx, "osascript", "-e", script).Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseNativeIDs(string(output)), nil
+}
+
+func parseNativeIDs(output string) []string {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return nil
+	}
+	parts := strings.Split(output, ",")
+	ids := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if id := strings.TrimSpace(part); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func mcpViewIDs(ctx context.Context, endpoint string) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiKey := os.Getenv("THINGS_MCP_API_KEY"); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected HTTP status %s", resp.Status)
+	}
+
+	var tasks []task
+	if err := json.NewDecoder(resp.Body).Decode(&tasks); err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(tasks))
+	for _, item := range tasks {
+		if item.UUID == "" {
+			return nil, errors.New("response contains task without UUID")
+		}
+		ids = append(ids, item.UUID)
+	}
+	return ids, nil
+}
+
+func diffIDs(want, got []string) (missing, extra []string) {
+	wantSet := make(map[string]struct{}, len(want))
+	gotSet := make(map[string]struct{}, len(got))
+	for _, id := range want {
+		wantSet[id] = struct{}{}
+	}
+	for _, id := range got {
+		gotSet[id] = struct{}{}
+	}
+	for id := range wantSet {
+		if _, ok := gotSet[id]; !ok {
+			missing = append(missing, id)
+		}
+	}
+	for id := range gotSet {
+		if _, ok := wantSet[id]; !ok {
+			extra = append(extra, id)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(extra)
+	return missing, extra
+}

--- a/cmd/parity/main_test.go
+++ b/cmd/parity/main_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseNativeIDs(t *testing.T) {
+	t.Parallel()
+
+	got := parseNativeIDs("id-1, id-2, id-3\n")
+	want := []string{"id-1", "id-2", "id-3"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseNativeIDs() = %v, want %v", got, want)
+	}
+}
+
+func TestDiffIDs(t *testing.T) {
+	t.Parallel()
+
+	missing, extra := diffIDs([]string{"b", "a"}, []string{"c", "b"})
+	if !reflect.DeepEqual(missing, []string{"a"}) || !reflect.DeepEqual(extra, []string{"c"}) {
+		t.Fatalf("diffIDs() missing=%v extra=%v", missing, extra)
+	}
+}
+
+func TestMCPViewIDs(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, `[{"UUID":"id-1"},{"uuid":"id-2"}]`)
+	}))
+	defer server.Close()
+
+	got, err := mcpViewIDs(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("mcpViewIDs failed: %v", err)
+	}
+	if want := []string{"id-1", "id-2"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("mcpViewIDs() = %v, want %v", got, want)
+	}
+}
+
+func TestCompareViewsReportsMismatch(t *testing.T) {
+	t.Parallel()
+
+	native := func(_ context.Context, _ string) ([]string, error) {
+		return []string{"native-only", "shared"}, nil
+	}
+	mcp := func(_ context.Context, endpoint string) ([]string, error) {
+		if !strings.HasPrefix(endpoint, "http://127.0.0.1:8765/api/tasks/") {
+			return nil, fmt.Errorf("unexpected endpoint %s", endpoint)
+		}
+		return []string{"shared", "mcp-only"}, nil
+	}
+
+	var output strings.Builder
+	mismatch, err := compareViews(context.Background(), &output, "http://127.0.0.1:8765", native, mcp)
+	if err != nil {
+		t.Fatalf("compareViews failed: %v", err)
+	}
+	if !mismatch {
+		t.Fatal("expected mismatch")
+	}
+	if !strings.Contains(output.String(), "Today native=2 mcp=2 missing=1 extra=1") {
+		t.Fatalf("unexpected output: %s", output.String())
+	}
+}
+
+func TestCompareViewsRejectsDuplicateIDs(t *testing.T) {
+	t.Parallel()
+
+	native := func(_ context.Context, _ string) ([]string, error) {
+		return []string{"shared"}, nil
+	}
+	mcp := func(_ context.Context, _ string) ([]string, error) {
+		return []string{"shared", "shared"}, nil
+	}
+
+	mismatch, err := compareViews(context.Background(), io.Discard, "http://127.0.0.1:8765", native, mcp)
+	if err != nil {
+		t.Fatalf("compareViews failed: %v", err)
+	}
+	if !mismatch {
+		t.Fatal("expected duplicate IDs to fail parity")
+	}
+}

--- a/docs/2026-03-05-mcp-today-mismatch-incident.md
+++ b/docs/2026-03-05-mcp-today-mismatch-incident.md
@@ -2,7 +2,19 @@
 
 ## Status
 
-Closed. The original March 5 fixes addressed cursoring, concurrent sync, and read-path error surfacing. A later follow-up on **2026-03-15** fixed stale `today_index_ref` carry-over on partial task updates and added a schema migration that forces a clean local resync for old corrupted caches. See [2026-03-15-stability-wrap-up.md](2026-03-15-stability-wrap-up.md).
+Closed. The original March 5 fixes addressed cursoring, concurrent sync, and read-path error surfacing. A later follow-up on **2026-03-15** fixed stale `today_index_ref` carry-over on partial task updates and added a schema migration that forces a clean local resync for old corrupted caches. A **2026-07-13** parity audit then corrected the remaining native-list classification gaps described below. See [2026-03-15-stability-wrap-up.md](2026-03-15-stability-wrap-up.md).
+
+## 2026-07-13 Native Parity Follow-up
+
+A UUID comparison against Things 3 showed that the mirror contained the missing tasks, but its list queries did not reproduce native Things rules:
+
+- Today omitted carried-over tasks because it used an exact-day window.
+- Anytime was treated as the complement of Today, but native Things includes Today tasks in Anytime.
+- Someday included tasks nested in projects or headings that native Someday hides.
+- Upcoming omitted repeating templates because repeater rules were not persisted in SQLite. The separate `rt` link marks generated instances and does not itself imply Upcoming.
+- Shared filters allowed canceled tasks and did not consistently hide tasks under inactive or trashed parents.
+
+The repair uses shared active-task visibility rules, preserves both repeater rules and recurrence links in schema version 5, and forces a one-time rebuild of the disposable cloud cache. `cmd/parity` now compares native and MCP UUID sets for all five core views and blocks rollout on any difference.
 
 ## Summary
 

--- a/docs/endpoints-and-things-cloud.md
+++ b/docs/endpoints-and-things-cloud.md
@@ -89,8 +89,8 @@ Once sync completes, the endpoint reads from the local `sync.State()` API.
 Examples:
 
 - Inbox is a SQL query over tasks with `schedule = 0`
-- Today is a SQL query over tasks with `schedule = 1` and today's `scheduled_date` or `today_index_ref`
-- Anytime, Someday, and Upcoming are **derived locally** from schedule/date fields in the synced task rows
+- Today is a SQL query over active `schedule = 1` tasks whose `scheduled_date` or `today_index_ref` is earlier than the next UTC day boundary. This preserves Things carry-over behavior.
+- Anytime, Someday, and Upcoming are **derived locally** from schedule, date, placement, visibility, and recurrence fields in the synced task rows.
 
 There is no separate Things Cloud "Anytime endpoint" or "Someday endpoint". Those views are computed from synced history state.
 
@@ -98,9 +98,11 @@ There is no separate Things Cloud "Anytime endpoint" or "Someday endpoint". Thos
 
 The new dedicated queries are still based on the same underlying task fields:
 
-- **Anytime**: `schedule = 1` and not classified into Today
-- **Someday**: `schedule = 2` and not future-dated
-- **Upcoming**: `schedule = 2` with a future `scheduled_date` or `today_index_ref`
+- **Anytime**: all active `schedule = 1` tasks. Native Things treats this as an inclusive view, so Today tasks also appear here.
+- **Someday**: standalone, non-recurring `schedule = 2` tasks that are not future-dated.
+- **Upcoming**: active `schedule = 2` tasks with a future `scheduled_date` or `today_index_ref`, plus repeating templates carrying a repeater rule (`rr`). Generated instances link back through `rt` and are not automatically Upcoming.
+
+All five core views exclude canceled, deleted, trashed, and hidden-by-parent tasks by default.
 
 So these read endpoints are best understood as:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -137,7 +137,19 @@ Fly.io doesn't bill you if your monthly usage is under $5. The server scales to 
 | `THINGS_PASSWORD` | Yes | Your Things account password |
 | `API_KEY` | No | Bearer token for REST API endpoints (`/api/*`). If unset, no auth required. |
 | `PORT` | No | Server port (default: `8080`) |
+| `BIND_ADDR` | No | Interface to bind. Use `127.0.0.1` for a Mac-only service; default binds all interfaces. |
+| `DB_PATH` | No | SQLite mirror path (default: `/data/things.db`) |
 | `DEBUG` | No | Set to `true` for verbose HTTP logging |
+
+### Mac-local parity check
+
+After the server has completed its initial sync, compare its five core views with native Things 3:
+
+```bash
+go run ./cmd/parity -url http://127.0.0.1:8765
+```
+
+Each line must report `missing=0 extra=0`. The command is read-only and exits non-zero if Things, the server, or any view comparison fails. Run it before changing MCP clients and again after deployment.
 
 ## Updating
 

--- a/docs/plans/2026-07-13-001-fix-native-view-parity-plan.md
+++ b/docs/plans/2026-07-13-001-fix-native-view-parity-plan.md
@@ -1,0 +1,293 @@
+---
+title: "fix: Match native Things views and consolidate runtime access"
+date: 2026-07-13
+type: fix
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+target_repo: things-cloud-mcp
+---
+
+# Fix Native Things View Parity and Consolidate Runtime Access
+
+## Goal Capsule
+
+- **Objective:** Make the local Things Cloud MCP on port 8765 accurately reproduce native Things list membership, then use it as the sole Things integration for Codex, Claude, and Hermes.
+- **Authority:** Native Things AppleScript UUID sets define list membership; the cloud mirror supplies MCP data and writes; this plan defines implementation and rollout order.
+- **Execution profile:** Characterization-first query repair followed by a reversible local rollout.
+- **Stop conditions:** Do not repoint Codex or Claude, disable port 7890, or replace the running 8765 binary unless focused tests pass and native-versus-MCP UUID parity is clean for the required views.
+- **Tail ownership:** The implementation run owns code, tests, local deployment, runtime cutover, rollback rehearsal, PR creation, and CI follow-through.
+
+---
+
+## Product Contract
+
+### Summary
+
+The Mac currently has two Things MCP services. The legacy Python service on port 7890 cannot open its database, while the Go Things Cloud service on port 8765 reads a current mirror but misclassifies native views. Hermes already uses 8765; Codex and Claude still use 7890. The desired end state is one reliable MCP endpoint on 8765, with AppleScript retained only as a read-only truth check and emergency diagnostic path.
+
+### Problem Frame
+
+Native Things and the 8765 API disagree even though the relevant task UUIDs exist in the cloud mirror. On 2026-07-13, native Today contained 39 tasks while 8765 returned 21. Inbox matched at 486, but Anytime, Someday, and Upcoming also showed count differences. The current SQL treats Today as an exact-date window, excludes completed tasks while allowing canceled tasks, and does not consistently account for tasks hidden by trashed or inactive parent containers. This makes the MCP unsafe as the common task surface for all runtimes.
+
+### Requirements
+
+**View correctness**
+
+- R1. The 8765 Today result must match the native Things Today UUID set, including carry-over tasks and excluding canceled, trashed, deleted, and hidden-by-parent tasks.
+- R2. Anytime must contain the full active `schedule=1` population, including tasks also shown in Today, matching native Things' inclusive view behavior.
+- R3. Inbox, Anytime, Someday, and Upcoming must each be compared by UUID against their native Things list before cutover; any mismatch must be fixed or explicitly block rollout.
+- R4. Default active-list queries must return pending tasks only; optional completed/trashed query behavior must remain deliberate and covered.
+
+**Operational reliability**
+
+- R5. The parity check must be read-only and must report counts plus missing and extra UUIDs without changing Things, the mirror, or runtime configuration.
+- R6. Existing MCP read and write capabilities must remain available after the query repair, including a controlled create/edit/complete/trash smoke cycle.
+- R7. The server must support the configured local database path without requiring the container-only `/data` layout.
+
+**Single integration**
+
+- R8. Codex, Claude, and Hermes must all use the same local MCP URL on port 8765 after parity and smoke checks pass.
+- R9. The legacy service on port 7890 must remain available until all three runtimes have been verified against 8765, then be disabled without deleting its environment or files.
+- R10. Rollback must restore the previous runtime registrations, 8765 binary/service state, and 7890 availability without touching Things data.
+- R11. The canonical 8765 service must bind to loopback only; it must not expose unauthenticated Things data or write tools on other network interfaces.
+
+### Acceptance Examples
+
+- AE1. Given a pending task carried into Today from an earlier date, when 8765 lists Today and Anytime, then the task appears once in each native view result.
+- AE2. Given a canceled task or a task inside a trashed project, when any active native view is listed, then 8765 does not return it.
+- AE3. Given the five core native lists, when the parity verifier runs, then every list reports zero missing UUIDs and zero extra UUIDs before cutover.
+- AE4. Given Codex, Claude, and Hermes after cutover, when each lists Today through its `things` MCP, then each reaches 8765 and receives the same result.
+- AE5. Given a failed deployment or runtime verification, when rollback is invoked, then the prior binary/configuration is restored and 7890 can be re-enabled without modifying Things tasks.
+
+### Scope Boundaries
+
+**In scope**
+
+- Native list classification for Today, Inbox, Anytime, Someday, and Upcoming.
+- Shared visibility rules for canceled, completed, trashed, deleted, and parent-hidden tasks.
+- A durable read-only native-versus-MCP parity verifier.
+- Local 8765 deployment, three-runtime cutover, legacy-service retirement, and rollback documentation.
+
+**Out of scope**
+
+- Replacing this repo with `wbopan/things-cloud-mcp` or using its public hosted endpoint.
+- Adding public multi-user OAuth, exposing 8765 beyond the local machine, or adopting `wbopan` tool names.
+- Changing Things task organization, dates, tags, projects, or Today ordering outside the controlled smoke-test item.
+- Using private or experimental Things scripting commands.
+
+### Assumptions
+
+- The cloud mirror is current enough for parity checks because all previously missing Today UUIDs were present in it and live reads trigger sync.
+- Native AppleScript list membership is the source of truth for this Mac, while the cloud service remains the write path.
+- The existing uncommitted `DB_PATH` support in `server/main.go` is intentional local-runtime work and should be preserved, tested, and incorporated rather than discarded.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. **Repair the existing repo instead of migrating servers.** It already provides the persistent SQLite mirror, REST surface, 36 MCP tools, and the deployed 8765 binary. The `wbopan` repo is prior art for Today/date handling and diagnostics, not the runtime target.
+- KTD2. **Treat list membership as a UUID-set contract.** Count equality can hide offsetting misses and extras; parity must compare exact native and MCP UUID sets.
+- KTD3. **Centralize default task visibility.** Pending status and parent-container visibility should be expressed once and reused by core view queries so canceled or hidden tasks cannot leak differently across lists.
+- KTD4. **Preserve native view overlap explicitly.** Today includes eligible `schedule=1` tasks with a relevant date before the next UTC day boundary; Anytime includes the complete active `schedule=1` population, including Today. Someday contains standalone deferred tasks, while Upcoming also includes repeating templates identified by their repeater rule (`rr`).
+- KTD5. **Persist recurrence state and rebuild the disposable mirror once.** The cache gains both repeater rules (`rr`) and generated-instance links (`rt`) already present in cloud history; the schema upgrade clears local aggregate state and resyncs it so old rows cannot remain semantically incomplete. This does not modify Things data.
+- KTD6. **Keep AppleScript outside the server request path.** It is a verifier and fallback diagnostic, not a runtime dependency for every MCP call.
+- KTD7. **Cut over only after proof, with legacy retirement last.** The 8765 binary is replaced reversibly, runtime registrations move one at a time, and 7890 is disabled only after all clients succeed.
+- KTD8. **Enforce local-only access at the listener.** The server gains an explicit bind-address setting and the Mac service uses loopback, avoiding a new authentication system while closing the current all-interface exposure.
+
+### High-Level Technical Design
+
+```mermaid
+flowchart TB
+  T["Native Things 3"] -->|"read-only UUID truth"| V["Parity verifier"]
+  C["Things Cloud"] --> S["8765 sync engine and SQLite mirror"]
+  S --> Q["Shared visibility and view predicates"]
+  Q --> M["MCP and REST list responses"]
+  M --> V
+  V -->|"zero missing and extra UUIDs"| G["Cutover gate"]
+  G --> R["Codex, Claude, and Hermes"]
+```
+
+```mermaid
+stateDiagram-v2
+  [*] --> DualServices
+  DualServices --> Candidate8765: tests and parity pass
+  Candidate8765 --> RuntimeCutover: deploy reversible binary
+  RuntimeCutover --> Canonical8765: all three clients verify reads and smoke write
+  RuntimeCutover --> RolledBack: any client or service check fails
+  Canonical8765 --> LegacyDisabled: stop 7890 and retain rollback assets
+  RolledBack --> DualServices
+```
+
+### Sequencing
+
+1. Characterize and repair shared visibility plus Today/Anytime behavior.
+2. Characterize the remaining native views and close any parity gaps.
+3. Add the reusable parity verifier and local database-path coverage.
+4. Deploy 8765 reversibly, verify read/write behavior, repoint clients, then disable 7890.
+
+---
+
+## Implementation Units
+
+### U1. Establish shared active-task visibility
+
+- **Goal:** Prevent canceled tasks and tasks hidden by deleted, trashed, completed, or canceled parent containers from leaking into active native views.
+- **Requirements:** R1, R3, R4; AE2.
+- **Dependencies:** None.
+- **Files:** `sync/state.go`, `sync/integration_test.go`.
+- **Approach:** Introduce a reusable query fragment or query builder for active task visibility, including direct project and heading-to-project ancestry. Preserve explicit `IncludeCompleted` and `IncludeTrashed` behavior instead of silently redefining those options.
+- **Execution note:** Add characterization coverage for the current query behavior, then strengthen it with failing cases before changing production SQL.
+- **Patterns to follow:** Existing `QueryOpts`, pagination helpers, executor locking, and temporary SQLite integration tests in `sync/integration_test.go`.
+- **Test scenarios:**
+  1. A pending standalone task is visible by default.
+  2. Canceled and completed tasks are excluded from default active queries.
+  3. A task whose direct project is trashed, deleted, completed, or canceled is excluded.
+  4. A task under a heading whose project is hidden is excluded.
+  5. `IncludeCompleted` and `IncludeTrashed` return only the additional states their names promise without weakening unrelated parent visibility.
+- **Verification:** Focused sync tests prove the shared visibility contract and existing pagination still returns stable results.
+
+### U2. Make Today and inclusive Anytime match native Things
+
+- **Goal:** Include carry-over Today tasks while keeping Anytime as native Things' inclusive active view.
+- **Requirements:** R1, R2, R4; AE1, AE2.
+- **Dependencies:** U1.
+- **Files:** `sync/state.go`, `sync/integration_test.go`, `sync/detect_test.go`.
+- **Approach:** Replace exact-current-date membership with an inclusive carry-over rule bounded by the next UTC day. Express Anytime with explicit null checks so SQL three-valued logic cannot drop undated tasks. Keep ordering behavior stable.
+- **Execution note:** Start by changing the existing Today/TIR test so an overdue pending task is expected in both Today and Anytime; observe the failure before implementation.
+- **Patterns to follow:** `currentUTCDayBounds`, `TestTasksInTodayWithTIR`, and UTC location tests in `sync/detect_test.go`.
+- **Test scenarios:**
+  1. Covers AE1. A task dated yesterday appears once in Today and once in Anytime.
+  2. A task dated today through either scheduled date or Today reference appears in Today exactly once.
+  3. An undated `schedule=1` task appears in Anytime and not Today.
+  4. A future-dated `schedule=1` task remains in Anytime and is excluded from Today until eligible.
+  5. Day-boundary values immediately before and at next UTC midnight classify deterministically.
+  6. Canceled and parent-hidden carry-over tasks remain absent.
+- **Verification:** Focused tests pass and the live parity verifier reports zero Today misses/extras before any runtime cutover.
+
+### U3. Characterize and repair Inbox, Someday, and Upcoming parity
+
+- **Goal:** Ensure every core list used by the three runtimes matches its native Things UUID set.
+- **Requirements:** R3, R4; AE2, AE3.
+- **Dependencies:** U1, U2.
+- **Files:** `sync/state.go`, `sync/store.go`, `sync/schema.go`, `sync/integration_test.go`, `sync/store_test.go`, `sync/sync_test.go`, `server/mcp_test.go`.
+- **Approach:** Use live native UUID differences to build minimal fixtures for project-contained tasks, headings, repeating templates, generated instances, nil dates, future dates, and hidden parents. Persist both `rr` and `rt` state from cloud history, rebuild older cache state through a schema migration, keep Someday to standalone deferred tasks without a repeater rule, and include repeater templates in Upcoming. Keep each list's rule explicit where Things semantics differ.
+- **Execution note:** Characterize each observed mismatch before changing its predicate. A view that already matches after U1 should receive regression coverage without extra production changes.
+- **Patterns to follow:** Dedicated view query methods in `sync/state.go` and MCP read-handler coverage in `server/mcp_test.go`.
+- **Test scenarios:**
+  1. Inbox remains unchanged for pending standalone and project tasks.
+  2. Someday excludes tasks that native Things hides because their containing project or heading is not visible.
+  3. Upcoming includes future scheduled tasks and repeating templates with `rr` even when the template has no future date field; `rt`-linked generated instances remain eligible for Someday.
+  4. Someday and Upcoming are mutually exclusive for eligible `schedule=2` tasks.
+  5. MCP list handlers return the same UUID membership as the underlying state queries with pagination disabled.
+  6. A schema-v4 cache upgrades to the recurrence-aware schema, clears incomplete aggregate state, and starts a clean cloud resync.
+- **Verification:** All five core list UUID sets match native Things on the live Mac, and focused fixtures document every changed rule.
+
+### U4. Add a durable read-only parity and deployment check
+
+- **Goal:** Make native-versus-8765 verification repeatable without ad hoc SQL or task mutation.
+- **Requirements:** R3, R5, R7, R11; AE3.
+- **Dependencies:** U2, U3.
+- **Files:** `cmd/parity/main.go`, `cmd/parity/main_test.go`, `cmd/README.md`, `server/main.go`, `server/main_test.go`, `docs/installation.md`.
+- **Approach:** Add a Mac-local diagnostic command that reads native list UUIDs through ordinary AppleScript, reads the five 8765 REST views, and reports counts plus missing/extra UUIDs. Return failure when any required view diverges or either source is unavailable. Preserve and test configurable `DB_PATH` startup behavior, and add a configurable HTTP bind address so the installed Mac service can be restricted to loopback without changing container defaults.
+- **Execution note:** Keep the verifier side-effect-free; use injected command/HTTP boundaries in tests rather than launching Things during the automated suite.
+- **Patterns to follow:** Existing `cmd/*` utilities, standard HTTP client timeouts, and startup helper tests in `server/main_test.go`.
+- **Test scenarios:**
+  1. Equal UUID sets in different orders report parity.
+  2. One missing and one extra UUID are both reported and produce failure.
+  3. Duplicate UUID input is normalized or rejected consistently.
+  4. AppleScript failure, malformed REST output, HTTP timeout, and unavailable service each produce a clear nonzero result.
+  5. An explicit database path is honored; absence falls back to `/data/things.db`.
+  6. An explicit loopback bind address is honored while the existing default remains compatible with container deployment.
+- **Verification:** Unit tests cover set comparison and failure handling; a live read-only run reports zero differences for all required views.
+
+### U5. Deploy 8765 and consolidate all runtimes
+
+- **Goal:** Make 8765 the single Things MCP used by Codex, Claude, and Hermes, then retire the broken 7890 service reversibly.
+- **Requirements:** R6, R8, R9, R10, R11; AE4, AE5.
+- **Dependencies:** U1, U2, U3, U4.
+- **Files:** `docs/installation.md`, `docs/2026-03-05-mcp-today-mismatch-incident.md`.
+- **Approach:** Record current binary, service, and runtime-registration state; build and install the candidate binary with a timestamped rollback copy; configure 8765 for loopback-only binding; restart only the 8765 LaunchAgent; run listener, health, parity, and controlled MCP smoke checks; repoint Codex then Claude while confirming Hermes remains correct; verify each in a fresh client process; finally unload and disable 7890 without deleting its files. Document exact rollback order and the final ownership model.
+- **Execution note:** Treat this as an operational gate. Any parity, smoke, or fresh-client failure stops the cutover and restores the previous state before further work.
+- **Patterns to follow:** Existing fail-fast startup, graceful shutdown, `things_smoke_test`, and the repo's prior incident documentation.
+- **Test scenarios:**
+  1. Candidate 8765 starts against the configured persistent database and passes health plus native parity.
+  2. The listener is reachable on loopback and absent from non-loopback interfaces.
+  3. The controlled smoke item completes the create/read/edit/complete/trash cycle and leaves no active residue.
+  4. Covers AE4. Fresh Codex, Claude, and Hermes processes each list Today through 8765 with identical membership.
+  5. 7890 remains running until all fresh-client checks pass, then is absent from listeners while 8765 remains healthy.
+  6. Covers AE5. A simulated failed client check follows the documented rollback path and restores prior registrations and service availability.
+- **Verification:** One listener remains for the canonical Things MCP, all three runtimes identify 8765 as `things`, native parity is clean, and rollback artifacts are retained.
+
+---
+
+## Verification Contract
+
+| Gate | Applies to | Verification | Done signal |
+|---|---|---|---|
+| Focused query tests | U1-U3 | `go test ./sync ./server` | All view and visibility fixtures pass |
+| Full Go suite | U1-U4 | `go test ./...` | No package regressions |
+| Static analysis | U1-U4 | `go vet ./...` | No findings |
+| Protocol/read regression | U3-U4 | Existing MCP protocol and read test suites | Tool discovery and list reads pass |
+| Native parity | U2-U5 | `go run ./cmd/parity` against the live 8765 service | Five views show zero missing and zero extra UUIDs |
+| Write smoke | U5 | Existing `things_smoke_test` through 8765 | Full lifecycle passes and cleanup succeeds |
+| Fresh-runtime checks | U5 | Codex, Claude, and Hermes each invoke `things` | All resolve 8765 and return the same Today set |
+| Listener exposure | U4-U5 | Inspect the active 8765 listener from loopback and a non-loopback address | Service is loopback-only |
+| Rollback readiness | U5 | Validate backups and service/config restore order | Previous state can be restored without Things-data edits |
+
+---
+
+## System-Wide Impact
+
+- **Users:** Marcus gains one consistent Things surface instead of runtime-dependent behavior.
+- **Data:** The disposable cloud mirror receives one additive schema migration and automatic full resync; the Things database is untouched. The smoke test creates one temporary item and trashes it during cleanup.
+- **Operations:** The 8765 LaunchAgent and three MCP registries change; 7890 is disabled only after validation.
+- **Security:** The service is bound to loopback before cutover. The public `wbopan` endpoint and its credential handling are not adopted.
+- **Compatibility:** Existing 36 MCP tool names stay stable, avoiding skill and prompt churn across runtimes.
+
+---
+
+## Risks and Dependencies
+
+- **Undocumented cloud semantics:** Things Cloud fields are reverse-engineered. Mitigation: native UUID characterization, focused fixtures, and no migration.
+- **App/cloud timing:** Native Things may update before cloud history arrives. Mitigation: parity checks sync first and distinguish unavailable/stale data from deterministic set differences.
+- **Parent hierarchy edge cases:** Tasks can be direct project children or heading children. Mitigation: fixtures cover both ancestry paths.
+- **Cache rebuild:** Persisting complete recurrence state requires one full mirror resync. Mitigation: fail-fast startup, untouched Things Cloud data, and a rollback copy of the prior binary and cache.
+- **Live cutover risk:** A bad binary or config can remove task access from all runtimes. Mitigation: one-runtime-at-a-time cutover, retained 7890 state, timestamped backups, and immediate rollback on failure.
+- **Network exposure:** The current 8765 process listens on all interfaces. Mitigation: add and verify an explicit loopback bind setting before considering the candidate deployable.
+- **External runtime files are outside git:** Their exact prior values cannot be recovered from the PR. Mitigation: capture backups and a concise local receipt before mutation; never store credentials in the repo.
+
+---
+
+## Documentation and Operational Notes
+
+- Update the existing mismatch incident with the final root cause, test coverage, and resolved parity evidence.
+- Update installation guidance for local `DB_PATH`, parity verification, loopback-only use, and reversible service rollout.
+- Keep credentials and runtime-specific secret values out of documentation, logs, commits, and PR text.
+- Do not delete the legacy Python environment or LaunchAgent file during this change; disabling is sufficient.
+
+---
+
+## Sources and Research
+
+- `README.md` and `CLAUDE.md` for the current repo architecture, tool surface, and sync model.
+- `sync/state.go`, `sync/integration_test.go`, and `types.go` for current view predicates and status semantics.
+- `docs/2026-03-05-mcp-today-mismatch-incident.md` and `docs/2026-03-15-stability-wrap-up.md` for prior cursor, concurrency, and stale-TIR incidents.
+- Live 2026-07-13 evidence: native Today 39 versus 8765 Today 21; Inbox 486 versus 486; additional mismatches in Anytime, Someday, and Upcoming; corrected Today visibility/date predicate matched 39 UUIDs with zero misses and extras.
+- [`wbopan/things-cloud-mcp`](https://github.com/wbopan/things-cloud-mcp) for prior art on carry-over Today filtering, diagnostics, and multi-client MCP transport. Its hosted architecture and public endpoint are not adopted.
+
+---
+
+## Definition of Done
+
+- R1-R10 are satisfied with no launch-blocking open questions.
+- U1-U5 verification outcomes pass and the full Go suite plus static analysis are clean.
+- The five native view UUID sets match 8765 immediately before and after runtime cutover.
+- Codex, Claude, and Hermes all use 8765 for `things`; no runtime still points to 7890.
+- The 8765 listener is bound to loopback only.
+- The 7890 listener is disabled only after successful cutover, and its files remain available for rollback.
+- The PR contains the query repair, regression tests, parity tool, and documentation without credentials or unrelated changes.
+- The local deployment has a tested rollback path and no user-authored Things data was modified beyond the cleaned-up smoke item.

--- a/server/main.go
+++ b/server/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -33,6 +34,17 @@ type shutdownServer interface {
 }
 
 const shutdownTimeout = 10 * time.Second
+
+func serverAddress(bindAddress, port string) string {
+	return net.JoinHostPort(bindAddress, port)
+}
+
+func envOrDefault(name, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+	return fallback
+}
 
 func jsonResponse(w http.ResponseWriter, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
@@ -377,16 +389,15 @@ func main() {
 		log.Fatal("THINGS_USERNAME and THINGS_PASSWORD must be set")
 	}
 
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8080"
-	}
+	port := envOrDefault("PORT", "8080")
+	bindAddress := os.Getenv("BIND_ADDR")
 
 	client = things.New(things.APIEndpoint, username, password)
 	client.Debug = os.Getenv("DEBUG") == "true"
 
+	dbPath := envOrDefault("DB_PATH", "/data/things.db")
 	var err error
-	syncer, err = sync.Open("/data/things.db", client)
+	syncer, err = sync.Open(dbPath, client)
 	if err != nil {
 		log.Fatalf("failed to open sync database: %v", err)
 	}
@@ -561,9 +572,10 @@ func main() {
 
 	shutdownCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	server := &http.Server{Addr: ":" + port}
+	address := serverAddress(bindAddress, port)
+	server := &http.Server{Addr: address}
 
-	log.Printf("Starting server on :%s", port)
+	log.Printf("Starting server on %s", address)
 	if err := serveWithGracefulShutdown(shutdownCtx, server, shutdownTimeout); err != nil {
 		log.Fatal(err)
 	}

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -43,6 +43,29 @@ func TestRunInitialSync(t *testing.T) {
 	})
 }
 
+func TestServerAddress(t *testing.T) {
+	t.Parallel()
+
+	if got, want := serverAddress("127.0.0.1", "8765"), "127.0.0.1:8765"; got != want {
+		t.Fatalf("serverAddress(loopback) = %q, want %q", got, want)
+	}
+	if got, want := serverAddress("", "8080"), ":8080"; got != want {
+		t.Fatalf("serverAddress(default) = %q, want %q", got, want)
+	}
+}
+
+func TestEnvOrDefault(t *testing.T) {
+	t.Setenv("THINGS_TEST_PATH", "/tmp/things.db")
+	if got, want := envOrDefault("THINGS_TEST_PATH", "/data/things.db"), "/tmp/things.db"; got != want {
+		t.Fatalf("envOrDefault(configured) = %q, want %q", got, want)
+	}
+
+	t.Setenv("THINGS_TEST_PATH", "")
+	if got, want := envOrDefault("THINGS_TEST_PATH", "/data/things.db"), "/data/things.db"; got != want {
+		t.Fatalf("envOrDefault(default) = %q, want %q", got, want)
+	}
+}
+
 type stubShutdownServer struct {
 	listenStarted  chan struct{}
 	shutdownCalled chan struct{}

--- a/state/memory/memory.go
+++ b/state/memory/memory.go
@@ -136,6 +136,9 @@ func (s *State) updateTask(item things.TaskActionItem) *things.Task {
 	if item.P.RecurrenceTaskIDs != nil {
 		t.RecurrenceIDs = *item.P.RecurrenceTaskIDs
 	}
+	if item.P.HasRepeater() {
+		t.Repeater = item.P.Repeater
+	}
 
 	return t
 }

--- a/sync/integration_test.go
+++ b/sync/integration_test.go
@@ -275,6 +275,69 @@ func TestTasksInTodayWithTIR(t *testing.T) {
 		TodayIndexReference: &yesterday,
 	})
 	syncer.saveTask(&things.Task{
+		UUID:          "canceled-today",
+		Title:         "Canceled Today",
+		Status:        things.TaskStatusCanceled,
+		Schedule:      things.TaskScheduleAnytime,
+		ScheduledDate: &today,
+	})
+	syncer.saveTask(&things.Task{
+		UUID:     "trashed-project",
+		Title:    "Trashed Project",
+		Type:     things.TaskTypeProject,
+		Status:   things.TaskStatusPending,
+		Schedule: things.TaskScheduleAnytime,
+		InTrash:  true,
+	})
+	syncer.saveTask(&things.Task{
+		UUID:          "task-in-trashed-project",
+		Title:         "Task in Trashed Project",
+		Status:        things.TaskStatusPending,
+		Schedule:      things.TaskScheduleAnytime,
+		ScheduledDate: &today,
+		ParentTaskIDs: []string{"trashed-project"},
+	})
+	syncer.saveTask(&things.Task{
+		UUID:          "heading-in-trashed-project",
+		Title:         "Heading in Trashed Project",
+		Type:          things.TaskTypeHeading,
+		Status:        things.TaskStatusPending,
+		Schedule:      things.TaskScheduleAnytime,
+		ParentTaskIDs: []string{"trashed-project"},
+	})
+	syncer.saveTask(&things.Task{
+		UUID:                "task-under-hidden-heading",
+		Title:               "Task Under Hidden Heading",
+		Status:              things.TaskStatusPending,
+		Schedule:            things.TaskScheduleAnytime,
+		TodayIndexReference: &today,
+		ActionGroupIDs:      []string{"heading-in-trashed-project"},
+	})
+	syncer.saveTask(&things.Task{
+		UUID:          "task-in-missing-project",
+		Title:         "Task in Missing Project",
+		Status:        things.TaskStatusPending,
+		Schedule:      things.TaskScheduleAnytime,
+		ScheduledDate: &today,
+		ParentTaskIDs: []string{"missing-project"},
+	})
+	syncer.saveTask(&things.Task{
+		UUID:          "heading-in-missing-project",
+		Title:         "Heading in Missing Project",
+		Type:          things.TaskTypeHeading,
+		Status:        things.TaskStatusPending,
+		Schedule:      things.TaskScheduleAnytime,
+		ParentTaskIDs: []string{"missing-project"},
+	})
+	syncer.saveTask(&things.Task{
+		UUID:                "task-under-orphan-heading",
+		Title:               "Task Under Orphan Heading",
+		Status:              things.TaskStatusPending,
+		Schedule:            things.TaskScheduleAnytime,
+		TodayIndexReference: &today,
+		ActionGroupIDs:      []string{"heading-in-missing-project"},
+	})
+	syncer.saveTask(&things.Task{
 		UUID:     "no-dates",
 		Title:    "No Dates",
 		Status:   things.TaskStatusPending,
@@ -298,14 +361,14 @@ func TestTasksInTodayWithTIR(t *testing.T) {
 		got[task.UUID] = true
 	}
 
-	expected := []string{"sr-only", "tir-only", "both-today", "sr-old-tir-today", "sr-today-tir-old"}
+	expected := []string{"sr-only", "tir-only", "both-today", "sr-old-tir-today", "sr-today-tir-old", "both-old"}
 	for _, uuid := range expected {
 		if !got[uuid] {
 			t.Errorf("expected task %q in Today, but not found", uuid)
 		}
 	}
 
-	notExpected := []string{"both-old", "no-dates", "inbox-with-tir"}
+	notExpected := []string{"canceled-today", "task-in-trashed-project", "task-under-hidden-heading", "task-in-missing-project", "task-under-orphan-heading", "no-dates", "inbox-with-tir"}
 	for _, uuid := range notExpected {
 		if got[uuid] {
 			t.Errorf("task %q should NOT be in Today", uuid)
@@ -314,6 +377,28 @@ func TestTasksInTodayWithTIR(t *testing.T) {
 
 	if len(tasks) != len(expected) {
 		t.Errorf("expected %d tasks in Today, got %d", len(expected), len(tasks))
+	}
+
+	anytimeTasks, err := syncer.State().TasksInAnytime(QueryOpts{})
+	if err != nil {
+		t.Fatalf("TasksInAnytime failed: %v", err)
+	}
+	anytimeGot := make(map[string]bool, len(anytimeTasks))
+	for _, task := range anytimeTasks {
+		anytimeGot[task.UUID] = true
+	}
+	if !anytimeGot["no-dates"] {
+		t.Error("expected undated task in Anytime")
+	}
+	for _, uuid := range expected {
+		if !anytimeGot[uuid] {
+			t.Errorf("Today task %q should also be in inclusive Anytime", uuid)
+		}
+	}
+	for _, uuid := range []string{"canceled-today", "task-in-trashed-project", "task-under-hidden-heading", "task-in-missing-project", "task-under-orphan-heading"} {
+		if anytimeGot[uuid] {
+			t.Errorf("hidden task %q should NOT be in Anytime", uuid)
+		}
 	}
 }
 
@@ -588,6 +673,9 @@ func TestStateQueries(t *testing.T) {
 	syncer.saveTask(&things.Task{UUID: "today-ref-1", Title: "Today via tir", Schedule: things.TaskScheduleAnytime, Status: things.TaskStatusPending, TodayIndexReference: &todayRef})
 	syncer.saveTask(&things.Task{UUID: "someday-1", Title: "Someday Task", Schedule: things.TaskScheduleSomeday, Status: things.TaskStatusPending})
 	syncer.saveTask(&things.Task{UUID: "someday-past-1", Title: "Someday Past Task", Schedule: things.TaskScheduleSomeday, Status: things.TaskStatusPending, ScheduledDate: &pastRef})
+	syncer.saveTask(&things.Task{UUID: "someday-project", Title: "Someday Project", Type: things.TaskTypeProject, Schedule: things.TaskScheduleAnytime, Status: things.TaskStatusPending})
+	syncer.saveTask(&things.Task{UUID: "someday-project-task", Title: "Deferred Project Task", Schedule: things.TaskScheduleSomeday, Status: things.TaskStatusPending, ParentTaskIDs: []string{"someday-project"}})
+	syncer.saveTask(&things.Task{UUID: "recurring-upcoming-1", Title: "Recurring Upcoming Task", Schedule: things.TaskScheduleSomeday, Status: things.TaskStatusPending, RecurrenceIDs: []string{"template-1"}})
 	syncer.saveTask(&things.Task{UUID: "upcoming-1", Title: "Upcoming Task", Schedule: things.TaskScheduleSomeday, Status: things.TaskStatusPending, ScheduledDate: &futureRef})
 	syncer.saveTask(&things.Task{UUID: "upcoming-ref-1", Title: "Upcoming via tir", Schedule: things.TaskScheduleSomeday, Status: things.TaskStatusPending, TodayIndexReference: &futureRef})
 	syncer.saveTask(&things.Task{UUID: "completed-1", Title: "Completed Task", Schedule: things.TaskScheduleAnytime, Status: things.TaskStatusCompleted, CompletionDate: &completedAtRecent})
@@ -641,8 +729,8 @@ func TestStateQueries(t *testing.T) {
 		if err != nil {
 			t.Fatalf("AllProjects failed: %v", err)
 		}
-		if len(projects) != 1 {
-			t.Errorf("expected 1 project, got %d", len(projects))
+		if len(projects) != 2 {
+			t.Errorf("expected 2 projects, got %d", len(projects))
 		}
 		if projects[0].Type != things.TaskTypeProject {
 			t.Error("returned task is not a project")
@@ -662,16 +750,22 @@ func TestStateQueries(t *testing.T) {
 		}
 	})
 
-	t.Run("TasksInAnytime returns undated anytime tasks", func(t *testing.T) {
+	t.Run("TasksInAnytime includes both undated and Today tasks", func(t *testing.T) {
 		tasks, err := state.TasksInAnytime(QueryOpts{})
 		if err != nil {
 			t.Fatalf("TasksInAnytime failed: %v", err)
 		}
-		if len(tasks) != 1 {
-			t.Fatalf("expected 1 anytime task, got %d", len(tasks))
+		if len(tasks) != 2 {
+			t.Fatalf("expected 2 anytime tasks, got %d", len(tasks))
 		}
-		if tasks[0].UUID != "anytime-1" {
-			t.Fatalf("expected anytime-1, got %s", tasks[0].UUID)
+		got := map[string]bool{}
+		for _, task := range tasks {
+			got[task.UUID] = true
+		}
+		for _, uuid := range []string{"anytime-1", "today-ref-1"} {
+			if !got[uuid] {
+				t.Errorf("expected %s in Anytime", uuid)
+			}
 		}
 	})
 
@@ -693,11 +787,17 @@ func TestStateQueries(t *testing.T) {
 		if err != nil {
 			t.Fatalf("TasksInUpcoming failed: %v", err)
 		}
-		if len(tasks) != 2 {
-			t.Fatalf("expected 2 upcoming tasks, got %d", len(tasks))
+		if len(tasks) != 3 {
+			t.Fatalf("expected 3 upcoming tasks, got %d", len(tasks))
 		}
-		if tasks[0].UUID != "upcoming-1" || tasks[1].UUID != "upcoming-ref-1" {
-			t.Fatalf("unexpected upcoming tasks: %s, %s", tasks[0].UUID, tasks[1].UUID)
+		got := map[string]bool{}
+		for _, task := range tasks {
+			got[task.UUID] = true
+		}
+		for _, uuid := range []string{"upcoming-1", "upcoming-ref-1", "recurring-upcoming-1"} {
+			if !got[uuid] {
+				t.Errorf("expected %s in Upcoming", uuid)
+			}
 		}
 	})
 

--- a/sync/integration_test.go
+++ b/sync/integration_test.go
@@ -675,7 +675,8 @@ func TestStateQueries(t *testing.T) {
 	syncer.saveTask(&things.Task{UUID: "someday-past-1", Title: "Someday Past Task", Schedule: things.TaskScheduleSomeday, Status: things.TaskStatusPending, ScheduledDate: &pastRef})
 	syncer.saveTask(&things.Task{UUID: "someday-project", Title: "Someday Project", Type: things.TaskTypeProject, Schedule: things.TaskScheduleAnytime, Status: things.TaskStatusPending})
 	syncer.saveTask(&things.Task{UUID: "someday-project-task", Title: "Deferred Project Task", Schedule: things.TaskScheduleSomeday, Status: things.TaskStatusPending, ParentTaskIDs: []string{"someday-project"}})
-	syncer.saveTask(&things.Task{UUID: "recurring-upcoming-1", Title: "Recurring Upcoming Task", Schedule: things.TaskScheduleSomeday, Status: things.TaskStatusPending, RecurrenceIDs: []string{"template-1"}})
+	syncer.saveTask(&things.Task{UUID: "recurrence-link-someday-1", Title: "Recurrence Link Without Rule", Schedule: things.TaskScheduleSomeday, Status: things.TaskStatusPending, RecurrenceIDs: []string{"template-1"}})
+	syncer.saveTask(&things.Task{UUID: "recurring-upcoming-1", Title: "Recurring Upcoming Task", Schedule: things.TaskScheduleSomeday, Status: things.TaskStatusPending, Repeater: &things.RepeaterConfiguration{Version: 4}})
 	syncer.saveTask(&things.Task{UUID: "upcoming-1", Title: "Upcoming Task", Schedule: things.TaskScheduleSomeday, Status: things.TaskStatusPending, ScheduledDate: &futureRef})
 	syncer.saveTask(&things.Task{UUID: "upcoming-ref-1", Title: "Upcoming via tir", Schedule: things.TaskScheduleSomeday, Status: things.TaskStatusPending, TodayIndexReference: &futureRef})
 	syncer.saveTask(&things.Task{UUID: "completed-1", Title: "Completed Task", Schedule: things.TaskScheduleAnytime, Status: things.TaskStatusCompleted, CompletionDate: &completedAtRecent})
@@ -774,11 +775,17 @@ func TestStateQueries(t *testing.T) {
 		if err != nil {
 			t.Fatalf("TasksInSomeday failed: %v", err)
 		}
-		if len(tasks) != 2 {
-			t.Fatalf("expected 2 someday tasks, got %d", len(tasks))
+		if len(tasks) != 3 {
+			t.Fatalf("expected 3 someday tasks, got %d", len(tasks))
 		}
-		if tasks[0].UUID != "someday-1" || tasks[1].UUID != "someday-past-1" {
-			t.Fatalf("unexpected someday tasks: %s, %s", tasks[0].UUID, tasks[1].UUID)
+		got := map[string]bool{}
+		for _, task := range tasks {
+			got[task.UUID] = true
+		}
+		for _, uuid := range []string{"someday-1", "someday-past-1", "recurrence-link-someday-1"} {
+			if !got[uuid] {
+				t.Errorf("expected %s in Someday", uuid)
+			}
 		}
 	})
 

--- a/sync/process.go
+++ b/sync/process.go
@@ -383,6 +383,7 @@ func applyTaskPayload(old *things.Task, uuid string, p things.TaskActionItemPayl
 		t.AlarmTimeOffset = old.AlarmTimeOffset
 		t.TagIDs = old.TagIDs
 		t.RecurrenceIDs = old.RecurrenceIDs
+		t.Repeater = old.Repeater
 		t.DelegateIDs = old.DelegateIDs
 	}
 
@@ -465,6 +466,9 @@ func applyTaskPayload(old *things.Task, uuid string, p things.TaskActionItemPayl
 	}
 	if p.RecurrenceTaskIDs != nil {
 		t.RecurrenceIDs = *p.RecurrenceTaskIDs
+	}
+	if p.HasRepeater() {
+		t.Repeater = p.Repeater
 	}
 	if p.DelegateIDs != nil {
 		t.DelegateIDs = *p.DelegateIDs

--- a/sync/schema.go
+++ b/sync/schema.go
@@ -1,6 +1,6 @@
 package sync
 
-const schemaVersion = 4
+const schemaVersion = 5
 
 const schema = `
 -- Schema version tracking
@@ -53,6 +53,7 @@ CREATE TABLE IF NOT EXISTS tasks (
     heading_uuid TEXT,
     alarm_time_offset INTEGER,
     recurrence_rule TEXT,
+    recurrence_ids TEXT,
     today_index_ref INTEGER,
     deleted INTEGER DEFAULT 0
 );
@@ -144,6 +145,21 @@ DELETE FROM change_log;
 DELETE FROM sync_state;
 `
 
+// migration5 stores recurrence references needed to reproduce the native
+// Upcoming view. The aggregate cache is disposable, so force a full rebuild
+// from Things Cloud after adding the column.
+const migration5 = `
+ALTER TABLE tasks ADD COLUMN recurrence_ids TEXT;
+DELETE FROM task_tags;
+DELETE FROM area_tags;
+DELETE FROM checklist_items;
+DELETE FROM tasks;
+DELETE FROM areas;
+DELETE FROM tags;
+DELETE FROM change_log;
+DELETE FROM sync_state;
+`
+
 func (s *Syncer) migrate() error {
 	// Check current version
 	var version int
@@ -162,24 +178,37 @@ func (s *Syncer) migrate() error {
 		return nil
 	}
 
+	tx, err := s.rawDB.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
 	// Incremental migrations
 	if version < 2 {
-		if _, err := s.db.Exec(migration2); err != nil {
+		if _, err := tx.Exec(migration2); err != nil {
 			return err
 		}
 	}
 	if version < 3 {
-		if _, err := s.db.Exec(migration3); err != nil {
+		if _, err := tx.Exec(migration3); err != nil {
 			return err
 		}
 	}
 	if version < 4 {
-		if _, err := s.db.Exec(migration4); err != nil {
+		if _, err := tx.Exec(migration4); err != nil {
+			return err
+		}
+	}
+	if version < 5 {
+		if _, err := tx.Exec(migration5); err != nil {
 			return err
 		}
 	}
 
 	// Update schema version
-	_, err = s.db.Exec("UPDATE schema_version SET version = ?", schemaVersion)
-	return err
+	if _, err := tx.Exec("UPDATE schema_version SET version = ?", schemaVersion); err != nil {
+		return err
+	}
+	return tx.Commit()
 }

--- a/sync/schema.go
+++ b/sync/schema.go
@@ -145,9 +145,8 @@ DELETE FROM change_log;
 DELETE FROM sync_state;
 `
 
-// migration5 stores recurrence references needed to reproduce the native
-// Upcoming view. The aggregate cache is disposable, so force a full rebuild
-// from Things Cloud after adding the column.
+// migration5 stores recurrence references and rebuilds the aggregate cache so
+// existing recurrence_rule rows are populated from Things Cloud history.
 const migration5 = `
 ALTER TABLE tasks ADD COLUMN recurrence_ids TEXT;
 DELETE FROM task_tags;

--- a/sync/state.go
+++ b/sync/state.go
@@ -185,7 +185,7 @@ func (st *State) TasksInSomeday(opts QueryOpts) ([]*things.Task, error) {
 	query, args := taskViewQuery(things.TaskScheduleSomeday, opts)
 	query += ` AND t.project_uuid IS NULL
 		AND t.heading_uuid IS NULL
-		AND t.recurrence_ids IS NULL
+		AND t.recurrence_rule IS NULL
 		AND NOT (
 		(t.scheduled_date IS NOT NULL AND t.scheduled_date > ?)
 		OR (t.today_index_ref IS NOT NULL AND t.today_index_ref > ?)
@@ -206,7 +206,7 @@ func (st *State) TasksInUpcoming(opts QueryOpts) ([]*things.Task, error) {
 	query += ` AND (
 		(t.scheduled_date IS NOT NULL AND t.scheduled_date > ?)
 		OR (t.today_index_ref IS NOT NULL AND t.today_index_ref > ?)
-		OR t.recurrence_ids IS NOT NULL
+		OR t.recurrence_rule IS NOT NULL
 	)`
 	args = append(args, nowUnix, nowUnix)
 	query += ` ORDER BY COALESCE(t.scheduled_date, t.today_index_ref), t."index"`

--- a/sync/state.go
+++ b/sync/state.go
@@ -144,114 +144,72 @@ func (st *State) AllTagsWithOpts(opts QueryOpts) ([]*things.Tag, error) {
 
 // TasksInInbox returns tasks in the Inbox
 func (st *State) TasksInInbox(opts QueryOpts) ([]*things.Task, error) {
-	query := `SELECT uuid FROM tasks WHERE type = 0 AND schedule = 0 AND deleted = 0`
-	args := []any{}
-	if !opts.IncludeCompleted {
-		query += " AND status != 3"
-	}
-	if !opts.IncludeTrashed {
-		query += " AND in_trash = 0"
-	}
-	query += ` ORDER BY "index"`
+	query, args := taskViewQuery(things.TaskScheduleInbox, opts)
+	query += ` ORDER BY t."index"`
 	query, args = paginateQuery(query, args, opts)
 	return st.queryTasks(query, args...)
 }
 
 // TasksInToday returns tasks in the Today view. A task appears in Today when
-// schedule=1 (started/anytime) AND either sr (scheduled_date) or tir
-// (today_index_ref) falls on today's date.
+// schedule=1 (started/anytime) and either sr (scheduled_date) or tir
+// (today_index_ref) falls before the next UTC day boundary. This includes
+// carry-over tasks that Things keeps in Today.
 func (st *State) TasksInToday(opts QueryOpts) ([]*things.Task, error) {
-	todayUnix, tomorrowUnix := currentUTCDayBounds()
+	_, tomorrowUnix := currentUTCDayBounds()
 
-	query := `SELECT uuid FROM tasks WHERE type = 0 AND schedule = 1
-		AND (
-			(scheduled_date >= ? AND scheduled_date < ?)
-			OR (today_index_ref >= ? AND today_index_ref < ?)
-		) AND deleted = 0`
-	args := []any{todayUnix, tomorrowUnix, todayUnix, tomorrowUnix}
-	if !opts.IncludeCompleted {
-		query += " AND status != 3"
-	}
-	if !opts.IncludeTrashed {
-		query += " AND in_trash = 0"
-	}
-	query += ` ORDER BY today_index, "index"`
-	query, args = paginateQuery(query, args, opts)
-
-	st.syncer.mu.RLock()
-	defer st.syncer.mu.RUnlock()
-
-	rows, err := st.executor().Query(query, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	return st.scanTaskUUIDs(rows)
-}
-
-// TasksInAnytime returns tasks in the Anytime view. A task appears in Anytime
-// when schedule=1 and it is not classified into Today for the current UTC day.
-func (st *State) TasksInAnytime(opts QueryOpts) ([]*things.Task, error) {
-	todayUnix, tomorrowUnix := currentUTCDayBounds()
-
-	query := `SELECT uuid FROM tasks WHERE type = 0 AND schedule = 1
-		AND NOT (
-			(scheduled_date IS NOT NULL AND scheduled_date >= ? AND scheduled_date < ?)
-			OR (today_index_ref IS NOT NULL AND today_index_ref >= ? AND today_index_ref < ?)
-		) AND deleted = 0`
-	args := []any{todayUnix, tomorrowUnix, todayUnix, tomorrowUnix}
-	if !opts.IncludeCompleted {
-		query += " AND status != 3"
-	}
-	if !opts.IncludeTrashed {
-		query += " AND in_trash = 0"
-	}
-	query += ` ORDER BY "index"`
+	query, args := taskViewQuery(things.TaskScheduleAnytime, opts)
+	query += ` AND (
+		(t.scheduled_date IS NOT NULL AND t.scheduled_date < ?)
+		OR (t.today_index_ref IS NOT NULL AND t.today_index_ref < ?)
+	)`
+	args = append(args, tomorrowUnix, tomorrowUnix)
+	query += ` ORDER BY t.today_index, t."index"`
 	query, args = paginateQuery(query, args, opts)
 	return st.queryTasks(query, args...)
 }
 
-// TasksInSomeday returns tasks in the Someday view. A task appears in Someday
-// when schedule=2 and it is not classified into Upcoming at the current time.
+// TasksInAnytime returns all active schedule=1 tasks. Native Things treats
+// Anytime as an inclusive view, so tasks shown in Today also appear here.
+func (st *State) TasksInAnytime(opts QueryOpts) ([]*things.Task, error) {
+	query, args := taskViewQuery(things.TaskScheduleAnytime, opts)
+	query += ` ORDER BY t."index"`
+	query, args = paginateQuery(query, args, opts)
+	return st.queryTasks(query, args...)
+}
+
+// TasksInSomeday returns standalone, non-recurring schedule=2 tasks that are
+// not classified into Upcoming at the current time.
 func (st *State) TasksInSomeday(opts QueryOpts) ([]*things.Task, error) {
 	nowUnix := currentUTCUnix()
 
-	query := `SELECT uuid FROM tasks WHERE type = 0 AND schedule = 2
+	query, args := taskViewQuery(things.TaskScheduleSomeday, opts)
+	query += ` AND t.project_uuid IS NULL
+		AND t.heading_uuid IS NULL
+		AND t.recurrence_ids IS NULL
 		AND NOT (
-			(scheduled_date IS NOT NULL AND scheduled_date > ?)
-			OR (today_index_ref IS NOT NULL AND today_index_ref > ?)
-		) AND deleted = 0`
-	args := []any{nowUnix, nowUnix}
-	if !opts.IncludeCompleted {
-		query += " AND status != 3"
-	}
-	if !opts.IncludeTrashed {
-		query += " AND in_trash = 0"
-	}
-	query += ` ORDER BY "index"`
+		(t.scheduled_date IS NOT NULL AND t.scheduled_date > ?)
+		OR (t.today_index_ref IS NOT NULL AND t.today_index_ref > ?)
+	)`
+	args = append(args, nowUnix, nowUnix)
+	query += ` ORDER BY t."index"`
 	query, args = paginateQuery(query, args, opts)
 	return st.queryTasks(query, args...)
 }
 
 // TasksInUpcoming returns tasks in the Upcoming view. A task appears in
 // Upcoming when schedule=2 and either sr (scheduled_date) or tir
-// (today_index_ref) is in the future.
+// (today_index_ref) is in the future, or it is a recurring instance.
 func (st *State) TasksInUpcoming(opts QueryOpts) ([]*things.Task, error) {
 	nowUnix := currentUTCUnix()
 
-	query := `SELECT uuid FROM tasks WHERE type = 0 AND schedule = 2
-		AND (
-			(scheduled_date IS NOT NULL AND scheduled_date > ?)
-			OR (today_index_ref IS NOT NULL AND today_index_ref > ?)
-		) AND deleted = 0`
-	args := []any{nowUnix, nowUnix}
-	if !opts.IncludeCompleted {
-		query += " AND status != 3"
-	}
-	if !opts.IncludeTrashed {
-		query += " AND in_trash = 0"
-	}
-	query += ` ORDER BY COALESCE(scheduled_date, today_index_ref), "index"`
+	query, args := taskViewQuery(things.TaskScheduleSomeday, opts)
+	query += ` AND (
+		(t.scheduled_date IS NOT NULL AND t.scheduled_date > ?)
+		OR (t.today_index_ref IS NOT NULL AND t.today_index_ref > ?)
+		OR t.recurrence_ids IS NOT NULL
+	)`
+	args = append(args, nowUnix, nowUnix)
+	query += ` ORDER BY COALESCE(t.scheduled_date, t.today_index_ref), t."index"`
 	query, args = paginateQuery(query, args, opts)
 	return st.queryTasks(query, args...)
 }
@@ -381,6 +339,39 @@ func currentUTCDayBounds() (int64, int64) {
 
 func currentUTCUnix() int64 {
 	return time.Now().UTC().Unix()
+}
+
+func taskViewQuery(schedule things.TaskSchedule, opts QueryOpts) (string, []any) {
+	query := `SELECT t.uuid FROM tasks t
+		LEFT JOIN tasks p ON p.uuid = t.project_uuid
+		LEFT JOIN tasks h ON h.uuid = t.heading_uuid
+		LEFT JOIN tasks hp ON hp.uuid = h.project_uuid
+		WHERE t.type = 0 AND t.schedule = ? AND t.deleted = 0`
+	args := []any{int(schedule)}
+
+	if opts.IncludeCompleted {
+		query += " AND t.status IN (?, ?)"
+		args = append(args, int(things.TaskStatusPending), int(things.TaskStatusCompleted))
+	} else {
+		query += " AND t.status = ?"
+		args = append(args, int(things.TaskStatusPending))
+	}
+
+	if !opts.IncludeTrashed {
+		query += ` AND t.in_trash = 0
+			AND (t.project_uuid IS NULL OR (p.status = ? AND p.deleted = 0 AND p.in_trash = 0))
+			AND (t.heading_uuid IS NULL OR (
+				h.status = ? AND h.deleted = 0 AND h.in_trash = 0
+				AND (h.project_uuid IS NULL OR (hp.status = ? AND hp.deleted = 0 AND hp.in_trash = 0))
+			))`
+		args = append(args,
+			int(things.TaskStatusPending),
+			int(things.TaskStatusPending),
+			int(things.TaskStatusPending),
+		)
+	}
+
+	return query, args
 }
 
 func paginateQuery(query string, args []any, opts QueryOpts) (string, []any) {

--- a/sync/store.go
+++ b/sync/store.go
@@ -2,6 +2,8 @@ package sync
 
 import (
 	"database/sql"
+	"encoding/json"
+	"fmt"
 	"time"
 
 	things "github.com/arthursoares/things-cloud-sdk"
@@ -15,7 +17,7 @@ func (s *Syncer) getTask(uuid string) (*things.Task, error) {
 				uuid, type, title, note, status, schedule,
 				scheduled_date, deadline_date, completion_date, creation_date, modification_date,
 				"index", today_index, in_trash, area_uuid, project_uuid, heading_uuid,
-				alarm_time_offset, recurrence_rule, today_index_ref, deleted
+				alarm_time_offset, recurrence_rule, recurrence_ids, today_index_ref, deleted
 			FROM tasks
 			WHERE uuid = ? AND deleted = 0
 		`, uuid)
@@ -36,6 +38,7 @@ func (s *Syncer) getTask(uuid string) (*things.Task, error) {
 		headingUUID      sql.NullString
 		alarmTimeOffset  sql.NullInt64
 		recurrenceRule   sql.NullString
+		recurrenceIDs    sql.NullString
 		todayIndexRef    sql.NullInt64
 		deleted          int
 	)
@@ -44,7 +47,7 @@ func (s *Syncer) getTask(uuid string) (*things.Task, error) {
 		&t.UUID, &taskType, &t.Title, &t.Note, &status, &schedule,
 		&scheduledDate, &deadlineDate, &completionDate, &creationDate, &modificationDate,
 		&t.Index, &t.TodayIndex, &inTrash, &areaUUID, &projectUUID, &headingUUID,
-		&alarmTimeOffset, &recurrenceRule, &todayIndexRef, &deleted,
+		&alarmTimeOffset, &recurrenceRule, &recurrenceIDs, &todayIndexRef, &deleted,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -99,6 +102,11 @@ func (s *Syncer) getTask(uuid string) (*things.Task, error) {
 	if alarmTimeOffset.Valid {
 		offset := int(alarmTimeOffset.Int64)
 		t.AlarmTimeOffset = &offset
+	}
+	if recurrenceIDs.Valid {
+		if err := json.Unmarshal([]byte(recurrenceIDs.String), &t.RecurrenceIDs); err != nil {
+			return nil, fmt.Errorf("decode recurrence IDs for task %s: %w", uuid, err)
+		}
 	}
 
 	// Load tags from junction table
@@ -168,6 +176,15 @@ func (s *Syncer) saveTask(t *things.Task) error {
 		todayIndexRef = sql.NullInt64{Int64: t.TodayIndexReference.Unix(), Valid: true}
 	}
 
+	var recurrenceIDs sql.NullString
+	if len(t.RecurrenceIDs) > 0 {
+		encoded, err := json.Marshal(t.RecurrenceIDs)
+		if err != nil {
+			return fmt.Errorf("encode recurrence IDs for task %s: %w", t.UUID, err)
+		}
+		recurrenceIDs = sql.NullString{String: string(encoded), Valid: true}
+	}
+
 	// Convert InTrash to integer
 	var inTrash int
 	if t.InTrash {
@@ -180,13 +197,13 @@ func (s *Syncer) saveTask(t *things.Task) error {
 			uuid, type, title, note, status, schedule,
 			scheduled_date, deadline_date, completion_date, creation_date, modification_date,
 			"index", today_index, in_trash, area_uuid, project_uuid, heading_uuid,
-			alarm_time_offset, recurrence_rule, today_index_ref, deleted
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+			alarm_time_offset, recurrence_rule, recurrence_ids, today_index_ref, deleted
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
 	`,
 		t.UUID, int(t.Type), t.Title, t.Note, int(t.Status), int(t.Schedule),
 		scheduledDate, deadlineDate, completionDate, creationDate, modificationDate,
 		t.Index, t.TodayIndex, inTrash, areaUUID, projectUUID, headingUUID,
-		alarmTimeOffset, sql.NullString{}, todayIndexRef, // recurrence_rule not directly on Task struct
+		alarmTimeOffset, sql.NullString{}, recurrenceIDs, todayIndexRef, // recurrence_rule not directly on Task struct
 	)
 	if err != nil {
 		return err

--- a/sync/store.go
+++ b/sync/store.go
@@ -108,6 +108,11 @@ func (s *Syncer) getTask(uuid string) (*things.Task, error) {
 			return nil, fmt.Errorf("decode recurrence IDs for task %s: %w", uuid, err)
 		}
 	}
+	if recurrenceRule.Valid {
+		if err := json.Unmarshal([]byte(recurrenceRule.String), &t.Repeater); err != nil {
+			return nil, fmt.Errorf("decode repeater for task %s: %w", uuid, err)
+		}
+	}
 
 	// Load tags from junction table
 	rows, err := s.db.Query(`SELECT tag_uuid FROM task_tags WHERE task_uuid = ?`, uuid)
@@ -185,6 +190,15 @@ func (s *Syncer) saveTask(t *things.Task) error {
 		recurrenceIDs = sql.NullString{String: string(encoded), Valid: true}
 	}
 
+	var recurrenceRule sql.NullString
+	if t.Repeater != nil {
+		encoded, err := json.Marshal(t.Repeater)
+		if err != nil {
+			return fmt.Errorf("encode repeater for task %s: %w", t.UUID, err)
+		}
+		recurrenceRule = sql.NullString{String: string(encoded), Valid: true}
+	}
+
 	// Convert InTrash to integer
 	var inTrash int
 	if t.InTrash {
@@ -203,7 +217,7 @@ func (s *Syncer) saveTask(t *things.Task) error {
 		t.UUID, int(t.Type), t.Title, t.Note, int(t.Status), int(t.Schedule),
 		scheduledDate, deadlineDate, completionDate, creationDate, modificationDate,
 		t.Index, t.TodayIndex, inTrash, areaUUID, projectUUID, headingUUID,
-		alarmTimeOffset, sql.NullString{}, recurrenceIDs, todayIndexRef, // recurrence_rule not directly on Task struct
+		alarmTimeOffset, recurrenceRule, recurrenceIDs, todayIndexRef,
 	)
 	if err != nil {
 		return err

--- a/sync/store_test.go
+++ b/sync/store_test.go
@@ -122,6 +122,7 @@ func TestTaskStorage(t *testing.T) {
 			ParentTaskIDs:       []string{"project-1"},
 			ActionGroupIDs:      []string{"heading-1"},
 			AlarmTimeOffset:     &alarmOffset,
+			RecurrenceIDs:       []string{"template-1", "template-2"},
 			TagIDs:              []string{"tag-a", "tag-b", "tag-c"},
 		}
 
@@ -170,6 +171,9 @@ func TestTaskStorage(t *testing.T) {
 		}
 		if len(retrieved.TagIDs) != 3 {
 			t.Errorf("TagIDs count mismatch: got %d", len(retrieved.TagIDs))
+		}
+		if len(retrieved.RecurrenceIDs) != 2 || retrieved.RecurrenceIDs[0] != "template-1" || retrieved.RecurrenceIDs[1] != "template-2" {
+			t.Errorf("RecurrenceIDs mismatch: got %v", retrieved.RecurrenceIDs)
 		}
 
 		// Verify dates (compare Unix timestamps to avoid timezone issues)

--- a/sync/store_test.go
+++ b/sync/store_test.go
@@ -101,6 +101,7 @@ func TestTaskStorage(t *testing.T) {
 		completion := now.Add(time.Hour)
 		modification := now.Add(30 * time.Minute)
 		alarmOffset := 3600
+		repeater := &things.RepeaterConfiguration{Version: 4}
 
 		task := &things.Task{
 			UUID:                "task-full",
@@ -123,6 +124,7 @@ func TestTaskStorage(t *testing.T) {
 			ActionGroupIDs:      []string{"heading-1"},
 			AlarmTimeOffset:     &alarmOffset,
 			RecurrenceIDs:       []string{"template-1", "template-2"},
+			Repeater:            repeater,
 			TagIDs:              []string{"tag-a", "tag-b", "tag-c"},
 		}
 
@@ -174,6 +176,9 @@ func TestTaskStorage(t *testing.T) {
 		}
 		if len(retrieved.RecurrenceIDs) != 2 || retrieved.RecurrenceIDs[0] != "template-1" || retrieved.RecurrenceIDs[1] != "template-2" {
 			t.Errorf("RecurrenceIDs mismatch: got %v", retrieved.RecurrenceIDs)
+		}
+		if retrieved.Repeater == nil || retrieved.Repeater.Version != 4 {
+			t.Errorf("Repeater mismatch: got %#v", retrieved.Repeater)
 		}
 
 		// Verify dates (compare Unix timestamps to avoid timezone issues)

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -109,6 +109,9 @@ func TestOpen(t *testing.T) {
 		if err := syncer.saveSyncState("history-1", 7); err != nil {
 			t.Fatalf("saveSyncState failed: %v", err)
 		}
+		if _, err := syncer.db.Exec(`ALTER TABLE tasks DROP COLUMN recurrence_ids`); err != nil {
+			t.Fatalf("restore v3 tasks schema failed: %v", err)
+		}
 		if _, err := syncer.db.Exec(`UPDATE schema_version SET version = 3`); err != nil {
 			t.Fatalf("downgrade schema version failed: %v", err)
 		}

--- a/types.go
+++ b/types.go
@@ -202,6 +202,7 @@ type Task struct {
 	AlarmTimeOffset     *int
 	TagIDs              []string
 	RecurrenceIDs       []string
+	Repeater            *RepeaterConfiguration `json:"-"`
 	DelegateIDs         []string
 }
 
@@ -245,6 +246,7 @@ type TaskActionItemPayload struct {
 	completionDateSet         bool                   `json:"-"`
 	deadlineDateSet           bool                   `json:"-"`
 	taskIRSet                 bool                   `json:"-"`
+	repeaterSet               bool                   `json:"-"`
 	//  {
 	//      "acrd": null,
 	//      "ar": [],
@@ -297,6 +299,7 @@ func (p *TaskActionItemPayload) UnmarshalJSON(bs []byte) error {
 	_, p.completionDateSet = raw["sp"]
 	_, p.deadlineDateSet = raw["dd"]
 	_, p.taskIRSet = raw["tir"]
+	_, p.repeaterSet = raw["rr"]
 	return nil
 }
 
@@ -318,6 +321,11 @@ func (p TaskActionItemPayload) HasDeadlineDate() bool {
 // HasTaskIR reports whether the payload explicitly included tir.
 func (p TaskActionItemPayload) HasTaskIR() bool {
 	return p.taskIRSet || p.TaskIR != nil
+}
+
+// HasRepeater reports whether the payload explicitly included rr.
+func (p TaskActionItemPayload) HasRepeater() bool {
+	return p.repeaterSet || p.Repeater != nil
 }
 
 // TaskActionItem describes an event on a Task

--- a/types_test.go
+++ b/types_test.go
@@ -136,6 +136,19 @@ func TestTaskActionItemPayload_AllFields(t *testing.T) {
 	if p.ExtensionData == nil {
 		t.Error("expected ExtensionData to be set")
 	}
+	if !p.HasRepeater() || p.Repeater != nil {
+		t.Error("expected Repeater to be explicitly present and nil")
+	}
+}
+
+func TestTaskActionItemPayload_RepeaterPresence(t *testing.T) {
+	var p TaskActionItemPayload
+	if err := json.Unmarshal([]byte(`{"rr":{"rrv":4,"fu":16,"fa":1,"of":[]}}`), &p); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if !p.HasRepeater() || p.Repeater == nil || p.Repeater.Version != 4 {
+		t.Fatalf("expected Repeater configuration, got %#v", p.Repeater)
+	}
 }
 
 func TestTaskActionItemPayload_NullableDatePresence(t *testing.T) {


### PR DESCRIPTION
## Summary

Things Cloud list results now match native Things 3 membership instead of exposing simplified local classifications. The five core views were verified by UUID on macOS after a fresh cloud rebuild: Today 39, Inbox 486, Anytime 2,130, Someday 234, and Upcoming 56, all with zero missing or extra items.

The repair preserves carried-over Today tasks, native Things' inclusive Anytime behavior, parent-container visibility, standalone Someday placement, and the distinction between repeating templates (`rr`) and generated instances (`rt`). Schema version 5 rebuilds only the disposable local mirror so recurrence state is complete; it does not mutate Things data.

The macOS parity command now blocks rollout on count or UUID differences. Local deployments can also set a persistent `DB_PATH` and bind to `127.0.0.1` without changing container defaults.

## Validation

- `go test -race ./... -count=1`
- `go vet ./...`
- `go build ./...`
- Fresh-cache native parity: all five core views matched exactly
- MCP lifecycle smoke test: 10/10 checks passed, including cleanup
- Local service restart: healthy on `127.0.0.1:8765`; 36 MCP tools discovered

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6_Sol_High-000000)
