### PR TITLE
Fix Today view dropping rolled-over tasks; exclude canceled tasks from all views

### DIFF
--- a/sync/integration_test.go
+++ b/sync/integration_test.go
@@ -298,14 +298,16 @@ func TestTasksInTodayWithTIR(t *testing.T) {
 		got[task.UUID] = true
 	}
 
-	expected := []string{"sr-only", "tir-only", "both-today", "sr-old-tir-today", "sr-today-tir-old"}
+	// "both-old" is scheduled entirely in the past. Things rolls overdue tasks
+	// forward into Today rather than hiding them, so it belongs here too.
+	expected := []string{"sr-only", "tir-only", "both-today", "sr-old-tir-today", "sr-today-tir-old", "both-old"}
 	for _, uuid := range expected {
 		if !got[uuid] {
 			t.Errorf("expected task %q in Today, but not found", uuid)
 		}
 	}
 
-	notExpected := []string{"both-old", "no-dates", "inbox-with-tir"}
+	notExpected := []string{"no-dates", "inbox-with-tir"}
 	for _, uuid := range notExpected {
 		if got[uuid] {
 			t.Errorf("task %q should NOT be in Today", uuid)

--- a/sync/state.go
+++ b/sync/state.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"database/sql"
+	"fmt"
 	"time"
 
 	things "github.com/arthursoares/things-cloud-sdk"
@@ -29,6 +30,17 @@ type QueryOpts struct {
 	Offset           int
 }
 
+// doneStatusClause returns the predicate excluding tasks the user is finished
+// with. Things treats canceled and completed as distinct statuses but hides
+// both from its views, so filtering on completion alone leaks canceled tasks.
+func doneStatusClause(opts QueryOpts) string {
+	if opts.IncludeCompleted {
+		return ""
+	}
+	return fmt.Sprintf(" AND status NOT IN (%d, %d)",
+		things.TaskStatusCanceled, things.TaskStatusCompleted)
+}
+
 // Task retrieves a task by UUID
 func (st *State) Task(uuid string) (*things.Task, error) {
 	st.syncer.mu.RLock()
@@ -54,9 +66,7 @@ func (st *State) Tag(uuid string) (*things.Tag, error) {
 func (st *State) AllTasks(opts QueryOpts) ([]*things.Task, error) {
 	query := `SELECT uuid FROM tasks WHERE type = 0 AND deleted = 0`
 	args := []any{}
-	if !opts.IncludeCompleted {
-		query += " AND status != 3"
-	}
+	query += doneStatusClause(opts)
 	if !opts.IncludeTrashed {
 		query += " AND in_trash = 0"
 	}
@@ -69,9 +79,7 @@ func (st *State) AllTasks(opts QueryOpts) ([]*things.Task, error) {
 func (st *State) AllProjects(opts QueryOpts) ([]*things.Task, error) {
 	query := `SELECT uuid FROM tasks WHERE type = 1 AND deleted = 0`
 	args := []any{}
-	if !opts.IncludeCompleted {
-		query += " AND status != 3"
-	}
+	query += doneStatusClause(opts)
 	if !opts.IncludeTrashed {
 		query += " AND in_trash = 0"
 	}
@@ -146,9 +154,7 @@ func (st *State) AllTagsWithOpts(opts QueryOpts) ([]*things.Tag, error) {
 func (st *State) TasksInInbox(opts QueryOpts) ([]*things.Task, error) {
 	query := `SELECT uuid FROM tasks WHERE type = 0 AND schedule = 0 AND deleted = 0`
 	args := []any{}
-	if !opts.IncludeCompleted {
-		query += " AND status != 3"
-	}
+	query += doneStatusClause(opts)
 	if !opts.IncludeTrashed {
 		query += " AND in_trash = 0"
 	}
@@ -159,19 +165,19 @@ func (st *State) TasksInInbox(opts QueryOpts) ([]*things.Task, error) {
 
 // TasksInToday returns tasks in the Today view. A task appears in Today when
 // schedule=1 (started/anytime) AND either sr (scheduled_date) or tir
-// (today_index_ref) falls on today's date.
+// (today_index_ref) falls on or before today's date. Things rolls overdue
+// tasks forward into Today rather than hiding them, so the bound is open at
+// the start: matching only today's date would drop every rolled-over task.
 func (st *State) TasksInToday(opts QueryOpts) ([]*things.Task, error) {
-	todayUnix, tomorrowUnix := currentUTCDayBounds()
+	_, tomorrowUnix := currentUTCDayBounds()
 
 	query := `SELECT uuid FROM tasks WHERE type = 0 AND schedule = 1
 		AND (
-			(scheduled_date >= ? AND scheduled_date < ?)
-			OR (today_index_ref >= ? AND today_index_ref < ?)
+			(scheduled_date IS NOT NULL AND scheduled_date < ?)
+			OR (today_index_ref IS NOT NULL AND today_index_ref < ?)
 		) AND deleted = 0`
-	args := []any{todayUnix, tomorrowUnix, todayUnix, tomorrowUnix}
-	if !opts.IncludeCompleted {
-		query += " AND status != 3"
-	}
+	args := []any{tomorrowUnix, tomorrowUnix}
+	query += doneStatusClause(opts)
 	if !opts.IncludeTrashed {
 		query += " AND in_trash = 0"
 	}
@@ -191,18 +197,18 @@ func (st *State) TasksInToday(opts QueryOpts) ([]*things.Task, error) {
 
 // TasksInAnytime returns tasks in the Anytime view. A task appears in Anytime
 // when schedule=1 and it is not classified into Today for the current UTC day.
+// This is the exact complement of TasksInToday and must stay in step with it,
+// or a rolled-over task shows up in both views at once.
 func (st *State) TasksInAnytime(opts QueryOpts) ([]*things.Task, error) {
-	todayUnix, tomorrowUnix := currentUTCDayBounds()
+	_, tomorrowUnix := currentUTCDayBounds()
 
 	query := `SELECT uuid FROM tasks WHERE type = 0 AND schedule = 1
 		AND NOT (
-			(scheduled_date IS NOT NULL AND scheduled_date >= ? AND scheduled_date < ?)
-			OR (today_index_ref IS NOT NULL AND today_index_ref >= ? AND today_index_ref < ?)
+			(scheduled_date IS NOT NULL AND scheduled_date < ?)
+			OR (today_index_ref IS NOT NULL AND today_index_ref < ?)
 		) AND deleted = 0`
-	args := []any{todayUnix, tomorrowUnix, todayUnix, tomorrowUnix}
-	if !opts.IncludeCompleted {
-		query += " AND status != 3"
-	}
+	args := []any{tomorrowUnix, tomorrowUnix}
+	query += doneStatusClause(opts)
 	if !opts.IncludeTrashed {
 		query += " AND in_trash = 0"
 	}
@@ -222,9 +228,7 @@ func (st *State) TasksInSomeday(opts QueryOpts) ([]*things.Task, error) {
 			OR (today_index_ref IS NOT NULL AND today_index_ref > ?)
 		) AND deleted = 0`
 	args := []any{nowUnix, nowUnix}
-	if !opts.IncludeCompleted {
-		query += " AND status != 3"
-	}
+	query += doneStatusClause(opts)
 	if !opts.IncludeTrashed {
 		query += " AND in_trash = 0"
 	}
@@ -245,9 +249,7 @@ func (st *State) TasksInUpcoming(opts QueryOpts) ([]*things.Task, error) {
 			OR (today_index_ref IS NOT NULL AND today_index_ref > ?)
 		) AND deleted = 0`
 	args := []any{nowUnix, nowUnix}
-	if !opts.IncludeCompleted {
-		query += " AND status != 3"
-	}
+	query += doneStatusClause(opts)
 	if !opts.IncludeTrashed {
 		query += " AND in_trash = 0"
 	}
@@ -260,9 +262,7 @@ func (st *State) TasksInUpcoming(opts QueryOpts) ([]*things.Task, error) {
 func (st *State) TasksInProject(projectUUID string, opts QueryOpts) ([]*things.Task, error) {
 	query := `SELECT uuid FROM tasks WHERE type = 0 AND project_uuid = ? AND deleted = 0`
 	args := []any{projectUUID}
-	if !opts.IncludeCompleted {
-		query += " AND status != 3"
-	}
+	query += doneStatusClause(opts)
 	if !opts.IncludeTrashed {
 		query += " AND in_trash = 0"
 	}
@@ -284,9 +284,7 @@ func (st *State) TasksInProject(projectUUID string, opts QueryOpts) ([]*things.T
 func (st *State) TasksInArea(areaUUID string, opts QueryOpts) ([]*things.Task, error) {
 	query := `SELECT uuid FROM tasks WHERE type = 0 AND area_uuid = ? AND deleted = 0`
 	args := []any{areaUUID}
-	if !opts.IncludeCompleted {
-		query += " AND status != 3"
-	}
+	query += doneStatusClause(opts)
 	if !opts.IncludeTrashed {
 		query += " AND in_trash = 0"
 	}

--- a/sync/state_views_test.go
+++ b/sync/state_views_test.go
@@ -1,0 +1,189 @@
+package sync
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+)
+
+// newViewTestSyncer opens an empty syncer backed by a temp database.
+func newViewTestSyncer(t *testing.T) *Syncer {
+	t.Helper()
+	syncer, err := Open(filepath.Join(t.TempDir(), "views.db"), nil)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	t.Cleanup(func() { syncer.Close() })
+	return syncer
+}
+
+// saveScheduled stores a schedule=1 task whose scheduled date is `dayOffset`
+// days from the current UTC day (negative values are in the past).
+func saveScheduled(t *testing.T, syncer *Syncer, uuid, title string, status things.TaskStatus, dayOffset int) {
+	t.Helper()
+	nowUTC := time.Now().UTC()
+	day := time.Date(nowUTC.Year(), nowUTC.Month(), nowUTC.Day(), 0, 0, 0, 0, time.UTC).
+		AddDate(0, 0, dayOffset)
+	task := &things.Task{
+		UUID:          uuid,
+		Title:         title,
+		Status:        status,
+		Schedule:      things.TaskScheduleAnytime,
+		Type:          things.TaskTypeTask,
+		ScheduledDate: &day,
+		CreationDate:  nowUTC,
+	}
+	if err := syncer.saveTask(task); err != nil {
+		t.Fatalf("saveTask(%s) failed: %v", uuid, err)
+	}
+}
+
+func titleSet(tasks []*things.Task) map[string]bool {
+	got := make(map[string]bool, len(tasks))
+	for _, task := range tasks {
+		got[task.Title] = true
+	}
+	return got
+}
+
+// Things rolls overdue tasks forward into Today instead of hiding them. A
+// same-day-only window silently returned an empty Today for anyone whose tasks
+// were all scheduled on an earlier date.
+func TestTasksInTodayIncludesRolledOverTasks(t *testing.T) {
+	t.Parallel()
+	syncer := newViewTestSyncer(t)
+
+	saveScheduled(t, syncer, "today-1", "Scheduled today", things.TaskStatusPending, 0)
+	saveScheduled(t, syncer, "overdue-1", "Scheduled yesterday", things.TaskStatusPending, -1)
+	saveScheduled(t, syncer, "overdue-2", "Scheduled last year", things.TaskStatusPending, -300)
+	saveScheduled(t, syncer, "future-1", "Scheduled tomorrow", things.TaskStatusPending, 1)
+
+	tasks, err := syncer.State().TasksInToday(QueryOpts{})
+	if err != nil {
+		t.Fatalf("TasksInToday failed: %v", err)
+	}
+	got := titleSet(tasks)
+
+	for _, want := range []string{"Scheduled today", "Scheduled yesterday", "Scheduled last year"} {
+		if !got[want] {
+			t.Errorf("TasksInToday missing %q; Today must include rolled-over tasks", want)
+		}
+	}
+	if got["Scheduled tomorrow"] {
+		t.Error("TasksInToday returned a future-dated task")
+	}
+}
+
+// Today and Anytime are complements: a task belongs to exactly one of them.
+func TestTodayAndAnytimeArePartitioned(t *testing.T) {
+	t.Parallel()
+	syncer := newViewTestSyncer(t)
+
+	saveScheduled(t, syncer, "today-1", "Scheduled today", things.TaskStatusPending, 0)
+	saveScheduled(t, syncer, "overdue-1", "Scheduled yesterday", things.TaskStatusPending, -1)
+	saveScheduled(t, syncer, "future-1", "Scheduled tomorrow", things.TaskStatusPending, 1)
+
+	state := syncer.State()
+	today, err := state.TasksInToday(QueryOpts{})
+	if err != nil {
+		t.Fatalf("TasksInToday failed: %v", err)
+	}
+	anytime, err := state.TasksInAnytime(QueryOpts{})
+	if err != nil {
+		t.Fatalf("TasksInAnytime failed: %v", err)
+	}
+
+	inToday, inAnytime := titleSet(today), titleSet(anytime)
+	for title := range inToday {
+		if inAnytime[title] {
+			t.Errorf("task %q appears in both Today and Anytime", title)
+		}
+	}
+	if len(today)+len(anytime) != 3 {
+		t.Errorf("Today(%d) + Anytime(%d) = %d, want 3 tasks total",
+			len(today), len(anytime), len(today)+len(anytime))
+	}
+}
+
+// Things hides canceled and completed tasks alike. Filtering on completion
+// alone left canceled tasks in every view.
+func TestViewsExcludeCanceledTasks(t *testing.T) {
+	t.Parallel()
+	syncer := newViewTestSyncer(t)
+
+	inbox := &things.Task{
+		UUID: "inbox-open", Title: "Open inbox task",
+		Status: things.TaskStatusPending, Schedule: things.TaskScheduleInbox,
+		Type: things.TaskTypeTask, CreationDate: time.Now().UTC(),
+	}
+	canceled := &things.Task{
+		UUID: "inbox-canceled", Title: "Canceled inbox task",
+		Status: things.TaskStatusCanceled, Schedule: things.TaskScheduleInbox,
+		Type: things.TaskTypeTask, CreationDate: time.Now().UTC(),
+	}
+	completed := &things.Task{
+		UUID: "inbox-completed", Title: "Completed inbox task",
+		Status: things.TaskStatusCompleted, Schedule: things.TaskScheduleInbox,
+		Type: things.TaskTypeTask, CreationDate: time.Now().UTC(),
+	}
+	for _, task := range []*things.Task{inbox, canceled, completed} {
+		if err := syncer.saveTask(task); err != nil {
+			t.Fatalf("saveTask(%s) failed: %v", task.UUID, err)
+		}
+	}
+
+	tasks, err := syncer.State().TasksInInbox(QueryOpts{})
+	if err != nil {
+		t.Fatalf("TasksInInbox failed: %v", err)
+	}
+	got := titleSet(tasks)
+	if !got["Open inbox task"] {
+		t.Error("TasksInInbox dropped the open task")
+	}
+	if got["Canceled inbox task"] {
+		t.Error("TasksInInbox returned a canceled task")
+	}
+	if got["Completed inbox task"] {
+		t.Error("TasksInInbox returned a completed task")
+	}
+
+	// Canceled tasks in Today were hidden by the old same-day window; they
+	// surface once rolled-over tasks are included, so cover that path too.
+	saveScheduled(t, syncer, "today-canceled", "Canceled overdue task", things.TaskStatusCanceled, -2)
+	todayTasks, err := syncer.State().TasksInToday(QueryOpts{})
+	if err != nil {
+		t.Fatalf("TasksInToday failed: %v", err)
+	}
+	if titleSet(todayTasks)["Canceled overdue task"] {
+		t.Error("TasksInToday returned a canceled task")
+	}
+}
+
+// IncludeCompleted remains an opt-in escape hatch for both done statuses.
+func TestIncludeCompletedReturnsCanceledAndCompleted(t *testing.T) {
+	t.Parallel()
+	syncer := newViewTestSyncer(t)
+
+	for _, task := range []*things.Task{
+		{UUID: "a", Title: "Open", Status: things.TaskStatusPending,
+			Schedule: things.TaskScheduleInbox, Type: things.TaskTypeTask, CreationDate: time.Now().UTC()},
+		{UUID: "b", Title: "Canceled", Status: things.TaskStatusCanceled,
+			Schedule: things.TaskScheduleInbox, Type: things.TaskTypeTask, CreationDate: time.Now().UTC()},
+		{UUID: "c", Title: "Completed", Status: things.TaskStatusCompleted,
+			Schedule: things.TaskScheduleInbox, Type: things.TaskTypeTask, CreationDate: time.Now().UTC()},
+	} {
+		if err := syncer.saveTask(task); err != nil {
+			t.Fatalf("saveTask(%s) failed: %v", task.UUID, err)
+		}
+	}
+
+	tasks, err := syncer.State().TasksInInbox(QueryOpts{IncludeCompleted: true})
+	if err != nil {
+		t.Fatalf("TasksInInbox failed: %v", err)
+	}
+	if len(tasks) != 3 {
+		t.Errorf("IncludeCompleted returned %d tasks, want 3", len(tasks))
+	}
+}


### PR DESCRIPTION
Two filtering bugs in `sync/state.go` made views return wrong data silently — no error, just missing or junk rows. Found while debugging an MCP client that kept reporting an empty Today.

## 1. `TasksInToday` drops rolled-over tasks

The window was closed at both ends:

```sql
(scheduled_date >= todayStart AND scheduled_date < tomorrowStart)
```

Things rolls overdue tasks *forward* into Today rather than hiding them — a task scheduled last Tuesday and left incomplete is still sitting in Today. The closed lower bound excluded every one of them, so Today only ever returned tasks scheduled for today's date exactly. For anyone who schedules ahead and works the backlog, that's a permanently empty Today.

Verified against a live Things database: all 9 tasks in the account's Today view were dated in the past (7 × yesterday, 2 × the prior September), and `TasksInToday` returned `[]`.

The same DB confirms the discriminator is "scheduled on or before today":

| `schedule=1`, open | count |
|---|---|
| scheduled ≤ today | 9 — matches Today exactly |
| scheduled in future | 0 — Things moves these to `schedule=2` |

Fix drops the lower bound. `TasksInAnytime` is the exact complement and is updated in step so nothing lands in both views — there's a test pinning that partition.

`schedule=1` with a future date isn't a state Things actually produces, but the upper bound is kept so the two predicates stay strict complements.

## 2. Canceled tasks were never filtered, in any view

Every view excluded done tasks with `status != 3` — `TaskStatusCompleted` only. `TaskStatusCanceled` is `2` and passed straight through, affecting Inbox, Today, Anytime, Someday, Upcoming, Project and Area.

On the account above, **23 of 30** rows from the Inbox query were canceled, pushing the 7 open tasks past a default page limit (a `limit: 15` call returned zero real tasks) and emitting full note bodies for tasks canceled months earlier.

Both statuses now route through a shared `doneStatusClause` helper. `IncludeCompleted` still works as the opt-in escape hatch and now covers both.

## Note on the changed test

`TestTasksInTodayWithTIR` asserted that `both-old` (scheduled_date and today_index_ref both yesterday) should *not* appear in Today. That encodes the same assumption as the bug, so I corrected the expectation rather than working around it. If Things really does hide fully-past-dated tasks in some case I haven't hit, that's the assertion to push back on — happy to rework.

## Testing

- `go build ./...`, `go vet ./sync/` clean
- `go test ./...` green
- Four new tests in `sync/state_views_test.go`: rollover inclusion, Today/Anytime partition, canceled exclusion (Inbox + Today), and `IncludeCompleted` opt-in